### PR TITLE
feat: Add generic msgpack decoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
-AUTO_BUILD_VERSION ?= dev
 GOPATH := $(shell go env GOPATH)
-
-build: BUILD/fluentlibtool
+OUTPUT ?= BUILD/fluentlibtool
 
 include ${GOPATH}/opt/gotils/Common.mk
-
-BUILD/fluentlibtool: Makefile go.mod $(SOURCES_NONTEST)
-	CGO_ENABLED=$${CGO_ENABLED:-0} GO_LDFLAGS="-X main.version=$(AUTO_BUILD_VERSION)" go build -o $@
 
 .PHONY: test-gen
 test-gen: BUILD/fluentlibtool

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -6,6 +6,7 @@ import (
 )
 
 type dumpCmdState struct {
+	IgnoreError bool `help:"Ignore errors"`
 }
 
 var dumpCmd = dumpCmdState{}
@@ -14,5 +15,8 @@ func (cmd *dumpCmdState) Run(args []string) {
 	if len(args) < 1 {
 		logger.Fatal("requires at least one file or directory")
 	}
-	dump.PrintFileOrDirectories(args)
+	err := dump.PrintFileOrDirectories(args, cmd.IgnoreError)
+	if err != nil {
+		logger.Fatal(err)
+	}
 }

--- a/dump/json.go
+++ b/dump/json.go
@@ -72,11 +72,8 @@ func PrintChunkFileInJSON(path string, indented bool, writer io.Writer) error {
 			if jerr != nil {
 				return fmt.Errorf("failed to format JSON: %w", jerr)
 			}
-			if _, err := writer.Write(jbin); err != nil {
+			if _, err := writer.Write(append(jbin, '\n')); err != nil {
 				return fmt.Errorf("failed to write output: %w", err)
-			}
-			if _, err := writer.Write([]byte("\n")); err != nil {
-				return fmt.Errorf("failed to write newline: %w", err)
 			}
 			logger.Debugf("completed decoding %s at position %d", path, decodedPos)
 		}


### PR DESCRIPTION
1. decoding of fluent-bit chunk format is limited to ".flb" files
2. decoding of forward message format is limited to ".ff" files
3. the rest are handled as one or more unknown msgpack blocks